### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,7 +30,7 @@
   },
   "productName": "vrc-social-manager",
   "mainBinaryName": "vrc-social-manager",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "com.meronmks.vsm",
   "plugins": {
     "updater": {


### PR DESCRIPTION
#90 のポカで抜け落ちてたやつ